### PR TITLE
Add submit button to allow for currency form to be submitted with no JS

### DIFF
--- a/includes/functions/alg-switcher-selector-functions.php
+++ b/includes/functions/alg-switcher-selector-functions.php
@@ -81,7 +81,9 @@ if ( ! function_exists( 'alg_get_currency_selector' ) ) {
 		}
 		if ( 'select' === $type ) {
 			$html .= '</select>';
-		}
+        }
+        // add noscript form submit function
+        $html .= '<noscript><input type="submit" value="Refresh"></noscript>';
 		$html .= '</form>';
 		return str_replace( '%currency_switcher%', $html, get_option( 'alg_currency_switcher_wrapper', '%currency_switcher%' ) );
 	}


### PR DESCRIPTION
In a web browser without javascript enabled, it is not possible for a user to
submit the currency form on product pages. Therefore, I added a refresh button
which displays when the user has javascript disabled, so they can submit the
form.
