### PR TITLE
Fix PHP 8.2 notice

### DIFF
--- a/includes/class-alg-exchange-rates-crons.php
+++ b/includes/class-alg-exchange-rates-crons.php
@@ -15,6 +15,8 @@ if ( ! class_exists( 'Alg_Currency_Switcher_Exchange_Rates_Crons' ) ) :
 
 class Alg_Currency_Switcher_Exchange_Rates_Crons {
 
+	public $update_intervals = null;
+	
 	/**
 	 * Constructor.
 	 *


### PR DESCRIPTION
Deprecated: Creation of dynamic property Alg_Currency_Switcher_Exchange_Rates_Crons::$update_intervals is deprecated in

currency-switcher-woocommerce/includes/class-alg-exchange-rates-crons.php on line 25