### PR TITLE
Fix php warning

### DIFF
--- a/includes/class-alg-widget-currency-switcher.php
+++ b/includes/class-alg-widget-currency-switcher.php
@@ -47,7 +47,9 @@ class Alg_Widget_Currency_Switcher extends WP_Widget {
 			echo $args['before_title'] . apply_filters( 'widget_title', $instance['title'] ) . $args['after_title'];
 		}
 		if ( 'yes' === get_option( 'alg_wc_currency_switcher_enabled', 'yes' ) ) {
-			switch ( $instance['switcher_type'] ) {
+			$switcher_type = isset( $instance['switcher_type'] ) ? $instance['switcher_type'] : null;
+			
+			switch ( $switcher_type ) {
 				case 'link_list':
 					echo alg_currency_select_link_list();
 					break;

--- a/readme.txt
+++ b/readme.txt
@@ -2,8 +2,8 @@
 Contributors: wpwham
 Tags: currency switcher, multicurrency, multi currency, currency, switcher
 Requires at least: 4.4
-Tested up to: 6.2
-Stable tag: 2.15.2
+Tested up to: 6.6
+Stable tag: 2.16.0
 License: GNU General Public License v3.0
 License URI: http://www.gnu.org/licenses/gpl-3.0.html
 
@@ -112,6 +112,11 @@ http://www.yoursite.com?alg_currency=USD
 `
 
 == Changelog ==
+
+= 2.16.0 - 2024-08-29 =
+* NEW: added new exchange rate server: Currencyapi.com.
+* UPDATE: reorganize settings slightly for improved clarity.
+* UPDATE: updated .pot file for translations.
 
 = 2.15.2 - 2023-07-07 =
 * FIX: PHP 8.2 notices.


### PR DESCRIPTION
PHP Warning: Undefined array key “switcher_type” on class-alg-widget-currency-switcher.php on line 50 when it is undefined