### PR TITLE
Try: leverage new customizable select feature when supported

### DIFF
--- a/assets/css/alg-native-select.css
+++ b/assets/css/alg-native-select.css
@@ -1,0 +1,51 @@
+/**
+ * Currency Switcher for WooCommerce - Native Select Styling
+ *
+ * Styles for the currency switcher dropdown when the browser supports
+ * customizable select elements (appearance: base-select).
+ *
+ * @version n.e.x.t
+ * @since   n.e.x.t
+ */
+
+@supports (appearance: base-select) {
+
+	/* Apply base appearance to the select element */
+	select.alg_currency_select {
+		appearance: base-select;
+		padding: 8px 30px 8px 12px;
+		border: 1px solid #ccc;
+		border-radius: 4px;
+		background-color: #fff;
+		background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16'%3E%3Cpath fill='none' stroke='%23333' stroke-linecap='round' stroke-linejoin='round' stroke-width='2' d='M2 5l6 6 6-6'/%3E%3C/svg%3E");
+		background-repeat: no-repeat;
+		background-position: right 8px center;
+		background-size: 1em;
+		cursor: pointer;
+		font-size: inherit; /* Inherit font size from parent */
+		line-height: inherit; /* Inherit line height */
+		min-width: 150px; /* Example minimum width */
+	}
+
+	/* Style options within the native select */
+	select.alg_currency_select option {
+		padding: 5px 10px;
+		/* Image is handled by the <img> tag in HTML */
+	}
+
+	/* Ensure wSelect elements are hidden if they accidentally render */
+	.wSelect-wrapper {
+		display: none !important;
+	}
+
+	/* Hide the original select when wSelect is active (shouldn't happen with our JS check, but as a fallback) */
+	body:not(._wSelect-ready) select.alg_currency_select.alg-wselect {
+		/* display: inline-block; */ /* Keep default display if wSelect isn't active */
+	}
+
+	/* Override wSelect specific class if flags are enabled but native select is used */
+	select.alg_currency_select.alg-wselect {
+		/* No special styles needed here when native is active */
+	}
+
+}

--- a/assets/css/alg-native-select.css
+++ b/assets/css/alg-native-select.css
@@ -22,30 +22,36 @@
 		background-position: right 8px center;
 		background-size: 1em;
 		cursor: pointer;
-		font-size: inherit; /* Inherit font size from parent */
+		font-size: .75em;
 		line-height: inherit; /* Inherit line height */
 		min-width: 150px; /* Example minimum width */
 	}
+	select.alg_currency_select::picker(select) {
+		appearance: base-select;
+	}
 
-	/* Style options within the native select */
+	select.alg_currency_select::picker-icon {
+		display: none;
+	}
+
+	select.alg_currency_select img {
+		border: 2px solid #ddd;
+		vertical-align: middle;
+		margin-right: 5px;
+		display: inline-block;
+	}
+
+	select.alg_currency_select::after {
+		content: ' ';
+ 	}
+	select.alg_currency_select::checkmark,
+	select.alg_currency_select option::checkmark,
+	select.alg_currency_select option::picker-icon {
+		display: none;
+	}
+
 	select.alg_currency_select option {
 		padding: 5px 10px;
-		/* Image is handled by the <img> tag in HTML */
-	}
-
-	/* Ensure wSelect elements are hidden if they accidentally render */
-	.wSelect-wrapper {
-		display: none !important;
-	}
-
-	/* Hide the original select when wSelect is active (shouldn't happen with our JS check, but as a fallback) */
-	body:not(._wSelect-ready) select.alg_currency_select.alg-wselect {
-		/* display: inline-block; */ /* Keep default display if wSelect isn't active */
-	}
-
-	/* Override wSelect specific class if flags are enabled but native select is used */
-	select.alg_currency_select.alg-wselect {
-		/* No special styles needed here when native is active */
 	}
 
 }

--- a/includes/class-alg-wc-currency-switcher.php
+++ b/includes/class-alg-wc-currency-switcher.php
@@ -400,9 +400,11 @@ class Alg_WC_Currency_Switcher_Main {
 	function enqueue_wselect_scripts() {
 		$plugin_url     = alg_wc_currency_switcher_plugin()->plugin_url();
 		$plugin_version = alg_wc_currency_switcher_plugin()->version;
-		wp_enqueue_style(  'alg-wselect-style', $plugin_url . '/includes/lib/wSelect/wSelect.css',    array(),           $plugin_version );
-		wp_enqueue_script( 'alg-wselect-lib',   $plugin_url . '/includes/lib/wSelect/wSelect.min.js', array( 'jquery' ), $plugin_version, true );
-		wp_enqueue_script( 'alg-wselect',       $plugin_url . '/includes/js/alg-wSelect.js',          array( 'jquery' ), $plugin_version, true );
+		wp_enqueue_style(  'alg-wselect-style',       $plugin_url . '/includes/lib/wSelect/wSelect.css',    array(),           $plugin_version );
+		// Enqueue the new style for native select elements
+		wp_enqueue_style(  'alg-native-select-style', $plugin_url . '/assets/css/alg-native-select.css', array(),           $plugin_version );
+		wp_enqueue_script( 'alg-wselect-lib',         $plugin_url . '/includes/lib/wSelect/wSelect.min.js', array( 'jquery' ), $plugin_version, true );
+		wp_enqueue_script( 'alg-wselect',             $plugin_url . '/includes/js/alg-wSelect.js',          array( 'jquery' ), $plugin_version, true );
 	}
 
 	/**

--- a/includes/functions/alg-switcher-selector-functions.php
+++ b/includes/functions/alg-switcher-selector-functions.php
@@ -48,7 +48,7 @@ if ( ! function_exists( 'alg_get_currency_selector' ) ) {
 		$html = '';
 		$html .= '<form action="" method="post" id="alg_currency_selector">';
 		if ( 'select' === $type ) {
-			$html .= '<select name="alg_currency" id="alg_currency_select" class="alg_currency_select' . ( $flags_enabled ? ' alg-wselect' : '' ) . '" onchange="this.form.submit()">';
+			$html .= '<select name="alg_currency" id="alg_currency_select" class="alg_currency_select' . ( $flags_enabled ? ' alg-wselect' : '' ) . '" onchange="this.form.submit()"><button><selectedcontent></selectedcontent></button>';
 		}
 		// Options
 		$function_currencies = alg_get_enabled_currencies();
@@ -65,7 +65,7 @@ if ( ! function_exists( 'alg_get_currency_selector' ) ) {
 						$country_code = alg_get_country_flag_code( $currency_code );
 						if ( ! empty( $country_code )  ) {
 							$flag_url = alg_get_country_flag_image_url( $country_code );
-							$flag_img_html = '<img src="' . esc_url( $flag_url ) . '" alt="" width="16" height="11" style="vertical-align: middle; margin-right: 5px; display: inline-block;" aria-hidden="true"> ';
+							$flag_img_html = '<img src="' . esc_url( $flag_url ) . '" alt="" width="16" height="11" aria-hidden="true"> ';
 						}
 					}
 					$html .= '<option id="alg_currency_' . $currency_code . '" value="' . $currency_code . '" ' . selected( $currency_code, $selected_currency, false ) . '>' .

--- a/includes/functions/alg-switcher-selector-functions.php
+++ b/includes/functions/alg-switcher-selector-functions.php
@@ -60,12 +60,16 @@ if ( ! function_exists( 'alg_get_currency_selector' ) ) {
 					$selected_currency = $currency_code;
 				}
 				if ( 'select' === $type ) {
-					$data_icon = '';
+					$flag_img_html = '';
 					if ( $flags_enabled ) {
 						$country_code = alg_get_country_flag_code( $currency_code );
-						$data_icon    = ' data-icon="' . alg_get_country_flag_image_url( $country_code ) . '"';
+						if ( ! empty( $country_code )  ) {
+							$flag_url = alg_get_country_flag_image_url( $country_code );
+							$flag_img_html = '<img src="' . esc_url( $flag_url ) . '" alt="" width="16" height="11" style="vertical-align: middle; margin-right: 5px; display: inline-block;" aria-hidden="true"> ';
+						}
 					}
-					$html .= '<option' . $data_icon . ' id="alg_currency_' . $currency_code . '" value="' . $currency_code . '" ' . selected( $currency_code, $selected_currency, false ) . '>' .
+					$html .= '<option id="alg_currency_' . $currency_code . '" value="' . $currency_code . '" ' . selected( $currency_code, $selected_currency, false ) . '>' .
+						$flag_img_html . // Add the image HTML here
 						alg_format_currency_switcher( $currencies[ $currency_code ], $currency_code ) . '</option>';
 				} elseif ( 'radio' === $type ) {
 					$flag_img = '';

--- a/includes/js/alg-wSelect.js
+++ b/includes/js/alg-wSelect.js
@@ -5,4 +5,7 @@
  * since   2.4.4
  */
 
-jQuery('select.alg-wselect').wSelect();
+// Initialize wSelect only if the browser doesn't support customizable select.
+if ( ! CSS.supports || ! CSS.supports( 'appearance', 'base-select' ) ) {
+	jQuery('select.alg-wselect').wSelect();
+}


### PR DESCRIPTION
## Summary
* Display flags in an actual select element with the flag images inline
* Loads the existing approach when the browsers doesn't support Customizable Select (https://developer.chrome.com/blog/a-customizable-select)
* Added some initial styling for the select, defaults can be fine tuned and themes can further customize

## Advantages
* Remove 3rd party dependencies for most users - uses pure HTML/CSS, no JavaScript required
* Its an actual Select element still, so:
  * You can style it (including loads of psuedo elements)
  * It works perfectly with Autofill
  * It's accessible out of the box

## TODO
- Adjust markup only for select 
- Testing on non supporting browsers to validate approach 

## Screenshot
Old
![image](https://github.com/user-attachments/assets/1a36ba65-4d0e-40e5-afff-19762f480c76)

New
![image](https://github.com/user-attachments/assets/4d3c6ccf-eec1-4801-8771-b5507cff9b5f)

